### PR TITLE
Replace Spanish sentence, adjust wording throughout

### DIFF
--- a/pages/properties.md
+++ b/pages/properties.md
@@ -19,12 +19,12 @@ Having the HTML properties of your website set properly ensures assitive technol
 
 #### Failure
 
-La manzana está verde.
+Sus ojos son verdes.
 
-> This text is spanish and no language tag is set
+> This text is Spanish and lacks a ```lang``` attribute.
 
 #### Passes 
 
-<p lang='es'>La manzana está verde.</p>
+<p lang="es">Sus ojos son verdes.</p>
 
-> This text passes because the ```lang``` attribute is set to spanish
+> This text passes because the ```lang="es"``` attribute identifies its content as Spanish.


### PR DESCRIPTION
The sentence *La manzana está verde* was ambiguous (if you're using *estar* it suggests that the apple is unripe, as opposed to using *ser* to describe its "permanent" color), so I replaced it with *Sus ojos son verdes*.

More importantly, though, I adjusted the wording to clarify the use of the `lang` attribute and capitalized the word Spanish.