### PR TITLE
Redirect gh-pages to production 18f-pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,6 +2,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta charset="utf-8">
   <title>{{ page.title }} - Accessibility Guide</title>
+  <meta http-equiv="refresh" content="0,URL={{ page.url | prepend: 'https://pages.18f.gov/accessibility' }}"></meta>
   <meta name="viewport" content="width=device-width">
   <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:300,600' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">


### PR DESCRIPTION
In talking about #44 we came up with two solutions:

0. Use a `<meta>` redirect to go to the production (`18f-pages` branch) accessibility guide
0. Nuke the `gh-pages` branch and just be done with it

Here's a PR in case we want to go with the first option. The pages should redirect to themselves at [pages.18f.gov/accessibility/:whatever-page](https://pages.18f.gov/accessibility/)

cc @konklone @mbland 