### PR TITLE
Fix writing guide nav item

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,6 +83,7 @@ navigation:
   internal: true
 - text: Writing Guide
   url: writing-guide/
+  internal: true
 
 repos:
 - name: Accessibility


### PR DESCRIPTION
Problem was, the nav item wasn't marked with `internal: true`, so it wasn't prefixing it with `{{ site.baseurl }}`.

cc: @nickbristow @awfrancisco 