### PR TITLE
add internal link marker (menu was pointing to a 404)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,6 +83,7 @@ navigation:
   internal: true
 - text: Writing Guide
   url: writing-guide/
+  internal: true
 
 repos:
 - name: Accessibility


### PR DESCRIPTION
Menu was pointing to < current URL > writing-guide/