### PR TITLE
Remove some stray s's, use spaces instead of tabs

### DIFF
--- a/pages/tables.md
+++ b/pages/tables.md
@@ -28,62 +28,62 @@ If a table has text associated with it, ensure the text is programatically linke
 ##### Simple Table
 
 <table>
-	<caption>User's Height and Weight</caption>
-	<tr>
-		<th scope="col">
-			Name
-		</th>
-		<th scope="col">
-			Height
-		</th>
-		<th scope="col">
-			Age
-		</th>
-	</tr>
-	<tr>
-		<th scope='row'>
-			Walter
-		</th>
-		<td>6'4</td>
-		<td>34</td>
-	</tr>
-	<tr>
-		<th scope='row'>
-			Steve
-		</th>
-		<td>5'4</td>
-		<td>30</td>
-	</tr>
+  <caption>User's Height and Weight</caption>
+  <tr>
+    <th scope="col">
+      Name
+    </th>
+    <th scope="col">
+      Height
+    </th>
+    <th scope="col">
+      Age
+    </th>
+  </tr>
+  <tr>
+    <th scope='row'>
+      Walter
+    </th>
+    <td>6'4</td>
+    <td>34</td>
+  </tr>
+  <tr>
+    <th scope='row'>
+      Steve
+    </th>
+    <td>5'4</td>
+    <td>30</td>
+  </tr>
 </table>
 
 ```html
 <table>
-	<caption>User's Height and Weight</caption>
-	<tr>
-		<th scope="col">
-			Name
-		</th>
-		<th scope="col">
-			Height
-		</th>
-		<th scope="col">
-			Age
-		</th>
-	</tr>
-	<tr>
-		<th scope='row'>
-			Walter
-		</th>
-		<td>6'4</td>
-		<td>34</td>
-	</tr>
-	<tr>
-		<th scope='row'>
-			Steve
-		</th>
-		<td>5'4</td>
-		<td>30</td>
-	</tr>
+  <caption>User's Height and Weight</caption>
+  <tr>
+    <th scope="col">
+      Name
+    </th>
+    <th scope="col">
+      Height
+    </th>
+    <th scope="col">
+      Age
+    </th>
+  </tr>
+  <tr>
+    <th scope='row'>
+      Walter
+    </th>
+    <td>6'4</td>
+    <td>34</td>
+  </tr>
+  <tr>
+    <th scope='row'>
+      Steve
+    </th>
+    <td>5'4</td>
+    <td>30</td>
+  </tr>
 </table>
 ```
 
@@ -92,81 +92,81 @@ If a table has text associated with it, ensure the text is programatically linke
 ##### Complex table
 
 <table>
-	<caption>User's Height and Weight</caption>
-	<tr>
-		<th rowspan='2' id='name'>
-			Name
-		</th>
-		<th colspan='2' id='height'>
-			Height
-		</th>
-		<th rowspan='2' id='age'>
-			Age
-		</th>
-	</tr>
-	<tr>
-		<th id='feet' headers='height'>
-			Feet
-		</th>
-		<th id='inches' headers='height'>
-			Inches
-		</th>
-	</tr>
-	<tr>
-		<th headers='name'>
-			Walter
-		</th>
-		<td headers='height feet'>6</td>
-		<td headers='height inches'>4</td>
-		<td headers='age'>34</td>
-	</tr>
-	<tr>
-		<th headers='name'>
-			Steve
-		</th>
-		<td headers='height feet's>5</td>
-		<td headers='height inches'>4</td>
-		<td headers='age'>30</td>
-	</tr>
+  <caption>User's Height and Weight</caption>
+  <tr>
+    <th rowspan='2' id='name'>
+      Name
+    </th>
+    <th colspan='2' id='height'>
+      Height
+    </th>
+    <th rowspan='2' id='age'>
+      Age
+    </th>
+  </tr>
+  <tr>
+    <th id='feet' headers='height'>
+      Feet
+    </th>
+    <th id='inches' headers='height'>
+      Inches
+    </th>
+  </tr>
+  <tr>
+    <th headers='name'>
+      Walter
+    </th>
+    <td headers='height feet'>6</td>
+    <td headers='height inches'>4</td>
+    <td headers='age'>34</td>
+  </tr>
+  <tr>
+    <th headers='name'>
+      Steve
+    </th>
+    <td headers='height feet'>5</td>
+    <td headers='height inches'>4</td>
+    <td headers='age'>30</td>
+  </tr>
 </table>
 
 ```html
 <table>
-	<caption>User's Height and Weight</caption>
-	<tr>
-		<th rowspan='2' id='name'>
-			Name
-		</th>
-		<th colspan='2' id='height'>
-			Height
-		</th>
-		<th rowspan='2' id='age'>
-			Age
-		</th>
-	</tr>
-	<tr>
-		<th id='feet' headers='height'>
-			Feet
-		</th>
-		<th id='inches' headers='height'>
-			Inches
-		</th>
-	<tr>
-		<th headers='name' id='walter'>
-			Walter
-		</th>
-		<td headers='height feet walter'>6</td>
-		<td headers='height inches walter'>4</td>
-		<td headers='age walter'>34</td>
-	</tr>
-	<tr>
-		<th headers='name' id='steve'>
-			Steve
-		</th>
-		<td headers='height feet steve's>5</td>
-		<td headers='height inches steve'>4</td>
-		<td headers='age steve'>30</td>
-	</tr>
+  <caption>User's Height and Weight</caption>
+  <tr>
+    <th rowspan='2' id='name'>
+      Name
+    </th>
+    <th colspan='2' id='height'>
+      Height
+    </th>
+    <th rowspan='2' id='age'>
+      Age
+    </th>
+  </tr>
+  <tr>
+    <th id='feet' headers='height'>
+      Feet
+    </th>
+    <th id='inches' headers='height'>
+      Inches
+    </th>
+  <tr>
+    <th headers='name' id='walter'>
+      Walter
+    </th>
+    <td headers='height feet walter'>6</td>
+    <td headers='height inches walter'>4</td>
+    <td headers='age walter'>34</td>
+  </tr>
+  <tr>
+    <th headers='name' id='steve'>
+      Steve
+    </th>
+    <td headers='height feet steve'>5</td>
+    <td headers='height inches steve'>4</td>
+    <td headers='age steve'>30</td>
+  </tr>
 </table>
 ```
 


### PR DESCRIPTION
This removes some stray `s` characters in the HTML snippets. Also, I replaced the tabs with 2 spaces, which I think makes the nested table tags easier to read (and less likely to overflow or wrap).