### PR TITLE
Add 18f-pages baseurl plugin

### DIFF
--- a/_plugins/18f-pages.rb
+++ b/_plugins/18f-pages.rb
@@ -1,0 +1,7 @@
+PAGES_BRANCHES = ['18f-pages']
+
+if PAGES_BRANCHES.include? ENV['BRANCH']
+    Jekyll::Hooks.register :site, :pre_render do |site|
+        site.config['baseurl'] = '/accessibility'
+    end
+end


### PR DESCRIPTION
This is a hotfix to solve the baseurl problem (documented [here](https://github.com/18F/brand/pull/120) for the brand guide) on Federalist, which should fix our public preview URLs.