### PR TITLE
Remove slang term, update copy

### DIFF
--- a/pages/tools.md
+++ b/pages/tools.md
@@ -24,7 +24,7 @@ These tools can be used to test sites for Section 508 and WCAG compliance in bro
 * [achecker](http://achecker.ca/) is an accessibility reporter for HTML only.
 * [Google's Accessibility Developer Tools](https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en) is a Chrome plugin for running basic accessibility tests from the comfort of your browser.
 * [Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/) is an IE tool that has been developed to aid manual examination of web pages for a variety of aspects of accessibility. It is used by DHS's Trusted Tester program.
-* [WAVE](http://wave.webaim.org/) is a comprehensive accessibility auditor with slick document introspection features.
+* [WAVE](http://wave.webaim.org/) is an accessibility auditor and browser extension with document inspection features.
 * The [W3C](http://www.w3.org/) maintains a comprehensive [list of web accessibility evaluation tools](http://www.w3.org/WAI/ER/tools/).
 
 ### Autocomplete Widgets


### PR DESCRIPTION
* The word "slick" is slang and shouldn't be used in this formal context.
* "Introspection" means to reflect on one's own thoughts and feelings, it is not what a 3rd party API does when it scans a webpage.
* Adding reference to browser extension
* We use "comprehensive" in the following sentence and it's an unnecessary modifier. Removing.