### PR TITLE
Consolidate tools, update some of the listed tools

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,25 +22,7 @@ __Disclaimer:__ This resource is intended to help 18F develop accessible product
 
 ### Testing Tools
 
-* [Accessibility Insights](https://accessibilityinsights.io/) - Windows application for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
-* Accessibility Management Platform (AMP): [GSA-specific info](https://insite.gsa.gov/employee-resources/information-technology/508-accessibility/accessibility-management-platform-amp) and [general product info](https://www.levelaccess.com/solutions/software/amp/)
-* [Colour Contrast Analyser](https://developer.paciellogroup.com/resources/contrastanalyser/) - Mac and Windows application to test for color contrast against WCAG 2.0 and 2.1 guidelines.
-* [HTML CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) - use this for a quick audit of any URL
-* [Pa11y Automated Tool](http://pa11y.org/) - Open-source
-* [Tenon](https://tenon.io/)
-* [tanaguru contrast finder](http://contrast-finder.tanaguru.com/) - Open-source tool to find better color contrast options.
-* [Accessible color palette builder](https://toolness.github.io/accessible-color-matrix/) - Open-source
-* [Windows: Inspector](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318521%28v=vs.85%29.aspx) - This tool is used by the DHS for their Trusted Tester Program.
-* [Windows: NVDA Screenreader](https://www.nvaccess.org/) - Open-source
-
-### Browser Testing Tools
-* [Chrome/Edge: Accessibility Insights](https://accessibilityinsights.io/) - Browser plugin for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
-* [Accessible Name & Description Inspector (ANDI) Tool](https://www.ssa.gov/accessibility/andi/help/install.html) - A web accessibility inspection tool maintained by the Accessible Solutions Branch within the Social Security Administration.
-* [Firefox: WCAG Contrast checker](https://addons.mozilla.org/EN-US/firefox/addon/wcag-contrast-checker/) - Fast way to evaluate CSS color contrast.
-* [Chrome:  Color Contrast Analyzer](https://chrome.google.com/webstore/detail/color-contrast-analyzer/dagdlcijhfbmgkjokkjicnnfimlebcll?hl=en) - Great for gradients & images.
-* [Chrome: Accessibility Developer Tools](https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en)
-* [Firefox/Chrome: WAVE Toolbar](http://wave.webaim.org/extension/)
-* [Firefox/Chrome: Web Developer](https://chrispederick.com/work/web-developer/)
+Please see [our tools page for a listing of accessibility testing tools](tools/). 
 
 ### Government Sites and tutorials
 * [Section 508](https://section508.gov/)

--- a/pages/tools.md
+++ b/pages/tools.md
@@ -23,7 +23,6 @@ sidenav: docs
 ### Accessibility Review Tools
 These tools can be used to test sites for Section 508 and WCAG compliance in browser:
 
-* [achecker](http://achecker.ca/) is an accessibility reporter for HTML only.
 * [Accessibility Insights](https://accessibilityinsights.io/) - Windows application for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
 * Accessibility Management Platform (AMP): [GSA-specific info](https://insite.gsa.gov/employee-resources/information-technology/508-accessibility/accessibility-management-platform-amp) and [general product info](https://www.levelaccess.com/solutions/software/amp/)
 * [Google's Accessibility Developer Tools](https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en) is a Chrome plugin for running basic accessibility tests from the comfort of your browser.

--- a/pages/tools.md
+++ b/pages/tools.md
@@ -23,7 +23,7 @@ sidenav: docs
 ### Accessibility Review Tools
 These tools can be used to test sites for Section 508 and WCAG compliance in browser:
 
-* [Accessibility Insights](https://accessibilityinsights.io/) - Windows application for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
+* [Accessibility Insights](https://accessibilityinsights.io/) - Browser plugin (Chrome, Edge), Android and Windows applications for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
 * Accessibility Management Platform (AMP): [GSA-specific info](https://insite.gsa.gov/employee-resources/information-technology/508-accessibility/accessibility-management-platform-amp) and [general product info](https://www.levelaccess.com/solutions/software/amp/)
 * [Google's Accessibility Developer Tools](https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb?hl=en) is a Chrome plugin for running basic accessibility tests from the comfort of your browser.
 * [Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/) is an IE tool that has been developed to aid manual examination of web pages for a variety of aspects of accessibility. It is used by [DHS's Trusted Tester program](https://www.dhs.gov/trusted-tester).
@@ -44,7 +44,9 @@ These tools can be used in automated tests and with continuous integration
 tools to help you ensure that your sites remain accessible throughout the
 development process:
 
+* [Accessibility Insights](https://accessibilityinsights.io/) - Browser plugin (Chrome, Edge), Android and Windows applications for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
 * [AccessLintCI](https://github.com/accesslint/accesslint-ci) runs accessibility tests in CircleCI builds and comments on GitHub pull requests with new accessibility issues. See more information on how to add this to an 18F site [here](https://github.com/18F/development-guide/tree/master/accessibility_scanning).
+* [axe](https://www.deque.com/axe/) - Suite of automated accessibility testing tools built around the open source [axe-core testing engine/ruleset](https://github.com/dequelabs/axe-core), by Deque.
 * [pa11y](http://pa11y.org/) is like a11y, but consists of a larger suite of tools, including command-line and JavaScript APIs, a [web service](https://github.com/nature/pa11y-webservice), and a [dashboard](https://github.com/nature/pa11y-dashboard) for monitoring accessibility reports across multiple sites.
 * [ra11y](https://github.com/benbalter/ra11y) is a Ruby-based accessibility testing tool tuned for use with [Jekyll](http://jekyllrb.com/) and static sites.
 * [webalin](http://webalin.readthedocs.org/en/latest/) is a Python-based 508 compliance linter for HTML.

--- a/pages/tools.md
+++ b/pages/tools.md
@@ -44,7 +44,6 @@ These tools can be used in automated tests and with continuous integration
 tools to help you ensure that your sites remain accessible throughout the
 development process:
 
-* [a11y](https://github.com/addyosmani/a11y) is a Node-based accessibility auditing with both command-line and JavaScript APIs.
 * [AccessLintCI](https://github.com/accesslint/accesslint-ci) runs accessibility tests in CircleCI builds and comments on GitHub pull requests with new accessibility issues. See more information on how to add this to an 18F site [here](https://github.com/18F/development-guide/tree/master/accessibility_scanning).
 * [pa11y](http://pa11y.org/) is like a11y, but consists of a larger suite of tools, including command-line and JavaScript APIs, a [web service](https://github.com/nature/pa11y-webservice), and a [dashboard](https://github.com/nature/pa11y-dashboard) for monitoring accessibility reports across multiple sites.
 * [ra11y](https://github.com/benbalter/ra11y) is a Ruby-based accessibility testing tool tuned for use with [Jekyll](http://jekyllrb.com/) and static sites.


### PR DESCRIPTION
[Preview link on Federalist](https://federalist-86ac2a7d-ee18-4863-bd98-a59377759671.app.cloud.gov/preview/18f/accessibility/consolidate-tools/)

Resolves #154
Resolves #258 

- Removes tools list from home/index page, and links instead to the tools page.
- Removes a11y and achecker links from tools page.
- Adds axe/axe-core to tools page.
- Updates tools page with info about Accessibility Insights.

Tools page needs a more thorough review and update. 

Suggestion: add link to the [W3C list of accessibility evaluation tools](https://www.w3.org/WAI/ER/tools/) for a more exhaustive list that we don't need to maintain, and then only link to specific tools that we (18F/TTS) are currently using. 


