### PR TITLE
add pa11y ignore rules for examples of fails

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -2,6 +2,7 @@
   "defaults": {
     "concurrency": 4,
     "standard": "WCAG2AA",
-    "runners": ["axe"]
+    "runners": ["axe"],
+    "hideElements": ".exampleFailure"
   }
 }

--- a/pages/color.md
+++ b/pages/color.md
@@ -35,11 +35,11 @@ Links that only rely on color also fail this requirement. Links must be distingu
 
 ### Failures
 
-<span style = "color:#58AA02">This text fails. </span>
+<span style = "color:#58AA02" class="exampleFailure">This text fails. </span>
 
 > This text fails because it's too light. The contrast ratio is (2.93 : 1).
 
-<span style = "color:#FFFFFF; background:#8D8E90">This text fails.</span>
+<span style = "color:#FFFFFF; background:#8D8E90" class="exampleFailure">This text fails.</span>
 
 > This text fails because the background isn't dark enough. The contrast ratio is (3.28 : 1).
 

--- a/pages/forms.md
+++ b/pages/forms.md
@@ -62,7 +62,7 @@ Making forms accessible is a simple process. Each form element should be associa
 
 ### Fails
 
-<fieldset>
+<fieldset class="exampleFailure">
   <legend>Name</legend>
   <label for="first_name-2">First</label>
   <input type='text' id='firstname-2'>
@@ -70,7 +70,7 @@ Making forms accessible is a simple process. Each form element should be associa
   <input type='text' id='1lastname'>
 </fieldset>
 
-<fieldset>
+<fieldset class="exampleFailure">
   <legend>Favorite Soup?</legend>
   <span style='color:#990000;'>This Question Is Required</span>
   <input type='radio' name='soup' value='pea' id='pea-2' title='Chick Pea Soup'><label for="pea-2">Pea Soup</label>
@@ -99,8 +99,6 @@ Making forms accessible is a simple process. Each form element should be associa
 ```
 
 > ___Failure:___ First name label ```for``` and ```id``` don't match.
-
-> ___Failure:___ Last name has an invalid ```id```.
 
 > ___Failure:___ "This Question Is Required" is not associated with the form fields.
 

--- a/pages/headings.md
+++ b/pages/headings.md
@@ -74,7 +74,7 @@ lorum ipsum
 
 ### Fails
 
-<div>
+<div class="exampleFailure">
   <h3>Category</h3>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sit amet auctor lectus. Curabitur non est nibh. Suspendisse vehicula fermentum quam. Donec lobortis diam a ligula faucibus mattis.</p>
   <h2>Sub Category 1</h2>

--- a/pages/iframes.md
+++ b/pages/iframes.md
@@ -19,7 +19,7 @@ When using `iframe`s, it's important that all content contained in them is acces
 
 ### Failures
 
-<iframe src="../iframeform/"></iframe>
+<iframe src="../iframeform/" class="exampleFailure"></iframe>
 
 ```html
 <iframe src="../iframeform/"></iframe>
@@ -27,7 +27,7 @@ When using `iframe`s, it's important that all content contained in them is acces
 
 > This `iframe` doesn't have a title or name.
 
-<iframe src="../iframeform/" name='Provide an address form'></iframe>
+<iframe src="../iframeform/" name='Provide an address form' class="exampleFailure"></iframe>
 
 ```html
 <iframe src="../iframeform/" name='Provide an address form'></iframe>

--- a/pages/images.md
+++ b/pages/images.md
@@ -39,7 +39,7 @@ When using images on a page, you must provide an alternate method for that conte
 
 ---
 
-<img src="{{site.baseurl}}/images/sign.jpg" title="Warning do not read this sign">
+<img src="{{site.baseurl}}/images/sign.jpg" title="Warning do not read this sign" class="exampleFailure">
 
 ```html
 <img src="{{site.baseurl}}/images/sign.jpg" title="Warning do not read this sign">
@@ -66,7 +66,7 @@ When using images on a page, you must provide an alternate method for that conte
 
 ### Incorrect
 
-<img src="{{site.baseurl}}/images/sign.jpg" >
+<img src="{{site.baseurl}}/images/sign.jpg" class="exampleFailure">
 
 ```html
 <img src="{{site.baseurl}}/images/sign.jpg">


### PR DESCRIPTION
Ready for review:

Pa11y config can be told to ignore the examples where we intentionally show a11y failures. In these commits, I'm using `.exampleFailure` for the items that we want Pa11y to exclude from testing so that builds do not fail.

This class is reusable for any future examples of failures we may add to the site. 