### PR TITLE
Applies consistent sentence casing to headings and subheadings

### DIFF
--- a/pages/checklist.md
+++ b/pages/checklist.md
@@ -54,6 +54,6 @@ It is important to note, while B and C are noted as less critical, they are stil
 4. <a href='../css/'>CSS is not required to use the page</a>
  * The page makes sense with or without CSS
 5. <a href='../links/'>Links are unique and contextual</a>
- * All links can be understood taken alone, i.e 'Read more - about 508'
+ * All links can be understood taken alone, e.g., 'Read more - about 508'
 6. <a href='../page-titles/'>Page titles are descriptive</a>
 7. <a href='../plugins/'>Required plugins are linked on the page</a>

--- a/pages/color.md
+++ b/pages/color.md
@@ -14,7 +14,7 @@ Links that only rely on color also fail this requirement. Links must be distingu
 
 ## Testing
 
-### Color Contrast
+### Color contrast
 
 1. Using a [color contrast checker](http://www.paciellogroup.com/resources/contrastanalyser/), compare the color of the text with the color of the background.
 2. In situations where the color is a gradient or cannot be determined programmatically, compare the lightest part of the text with the lightest part of the background using the color picker. Then compare the darkest part of the text with the darkest part of the background.
@@ -24,7 +24,7 @@ Links that only rely on color also fail this requirement. Links must be distingu
 
 **Note:** Logos, disabled form fields, and disabled buttons are **exempt** from this test and don't need to be tested for contrast.
 
-### Color Dependence
+### Color dependence
 
 1. Identify sections which use color to convey information.
 2. Check to see if the information is conveyed in another way visually and programatically.

--- a/pages/forms.md
+++ b/pages/forms.md
@@ -111,7 +111,7 @@ Screen readers vary on what they read and the additional information they provid
 
 You can test these with your own screen reader. If you have a OSX you can turn VoiceOver on by hitting command+F5.
 
-**Further Information** Using `aria-label` or `aria-labelledby` will cause a screen reader to only read them and not the default label. If you want an input to read from multiple things like an error message, use `aria-labelledby` and pass it the `for` attribute of the label and any additional `id`s you want read. ex. `aria-labelledby='car1 car_description car-error-message'`
+**Further information** Using `aria-label` or `aria-labelledby` will cause a screen reader to only read them and not the default label. If you want an input to read from multiple things like an error message, use `aria-labelledby` and pass it the `for` attribute of the label and any additional `id`s you want read. ex. `aria-labelledby='car1 car_description car-error-message'`
 
 #### No ARIA
 
@@ -127,7 +127,7 @@ Reads just the `label` and not the description
 <span id="carmakedescription_1"><i>Please enter Make and Model</i></span>
 ```
 
-**Screen Reader reads input as:** `Car Edit text`
+**Screen reader reads input as:** `Car Edit text`
 <hr>
 
 #### With aria-label
@@ -144,7 +144,7 @@ Reads the `aria-label` and doesn't read the normal `label`.
 <span id="carmakedescription_2"><i>Please enter Make and Model</i></span>
 ```
 
-**Screen Reader reads input as:** `Car, please enter make and model Edit text`
+**Screen reader reads input as:** `Car, please enter make and model Edit text`
 <hr>
 
 #### With aria-labelledby pointing at `carmakedescription`
@@ -161,7 +161,7 @@ Reads only the `aria-labelledby` attribute and not the default label
 <span id='carmakedescription_3'><i>Please enter Make and Model</i></span>
 ```
 
-**Screen Reader reads input as:** `Please enter Make and Model Edit text`
+**Screen reader reads input as:** `Please enter Make and Model Edit text`
 <hr>
 
 #### With aria-labelledby pointing at `carlabel carmakedescription`
@@ -178,7 +178,7 @@ Reads both labels indicated by the `aria-labelledby` attribute
 <span id="carmakedescription_4"><i>Please enter Make and Model</i></span>
 ```
 
-**Screen Reader reads input as:** `Car Please enter Make and Model Edit text`
+**Screen reader reads input as:** `Car Please enter Make and Model Edit text`
 <hr>
 
 #### With aria-describedby pointing at `carmakedescription`
@@ -195,5 +195,5 @@ JAWS reads both the label and the description. So does VoiceOver, but there is a
 <span id='carmakedescription_5'><i>Please enter Make and Model</i></span>
 ```
 
-**Screen Reader reads input as:** `Car Edit text Please enter Make and Model`
+**Screen reader reads input as:** `Car Edit text Please enter Make and Model`
 <hr>

--- a/pages/headings.md
+++ b/pages/headings.md
@@ -53,14 +53,14 @@ lorum ipsum
     Nam sit amet auctor lectus. Curabitur non est nibh. Suspendisse vehicula fermentum quam. 
     Donec lobortis diam a ligula faucibus mattis.
    </p>
-  <h4>Sub Category 1</h4>
+  <h4>Sub category 1</h4>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
     Nam sit amet auctor lectus. Curabitur non est nibh. 
     Suspendisse vehicula fermentum quam. 
     Donec lobortis diam a ligula faucibus mattis.
    </p>
-  <h4>Sub Category 2</h4>
+  <h4>Sub category 2</h4>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
     Nam sit amet auctor lectus. Curabitur non est nibh. 
@@ -92,14 +92,14 @@ lorum ipsum
     Suspendisse vehicula fermentum quam. 
     Donec lobortis diam a ligula faucibus mattis.
   </p>
-  <h2>Sub Category 1</h2>
+  <h2>Sub category 1</h2>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
     Nam sit amet auctor lectus. Curabitur non est nibh. 
     Suspendisse vehicula fermentum quam. 
     Donec lobortis diam a ligula faucibus mattis.
    </p>
-  <h5>Sub Category 2</h5>
+  <h5>Sub category 2</h5>
   <p>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
     Nam sit amet auctor lectus. Curabitur non est nibh. 

--- a/pages/hiddencontent.md
+++ b/pages/hiddencontent.md
@@ -1,5 +1,5 @@
 ---
-title: Hidden Content
+title: Hidden content
 description: 'How and when to hide content'
 permalink: /hidden-content/
 page_title: Hidden Content
@@ -39,13 +39,13 @@ Hiding content is very useful for accessibility. We can hide things visually and
       Technique
     </th>
     <th scope='col'>
-      Visually Hidden
+      Visually hidden
     </th>
     <th scope='col'>
       Screen reader hidden
     </th>
     <th scope='col'>
-      Additional Info
+      Additional info
     </th>
   </tr>
 </thead>
@@ -97,7 +97,7 @@ Hiding content is very useful for accessibility. We can hide things visually and
 </tbody>
 </table>
  
-## Aria Hidden
+## Aria hidden
 
 aria-hidden should be used in combination with these techniques. If we want to hide something from just the screen reader, you can mark it as `aria-hidden='true'`. 
 
@@ -151,7 +151,7 @@ This will hide completely and is the same as `<div aria-hidden='true' hidden>con
 - Repetitive information
 - Off screen content
 
-## Additional Resources
+## Additional resources
 
 For more information on this topic, see these articles. 
 

--- a/pages/keyboard.md
+++ b/pages/keyboard.md
@@ -61,7 +61,7 @@ Keyboard access to a website is key to the usability of your site. All interacti
 
 > Avoid using tabindex of >= 1 as this will disrupt the normal tab order of the page. tabindex of -1 is only appropriate when autofocusing an element not normally interactive.
 
-<h3 id='keyboard-trap'>Keyboard Trap</h3>
+<h3 id='keyboard-trap'>Keyboard trap</h3>
 
 <a class="sr-only moveFocus" href="#">hidden</a>
 

--- a/pages/links.md
+++ b/pages/links.md
@@ -14,7 +14,7 @@ The other issue screen reader and keyboard users come across is lengthy nav bars
 
 ## Testing
 
-### Unique Links
+### Unique links
 
 1. Identify all links on the page.
 2. Identify links with the same text.
@@ -22,7 +22,7 @@ The other issue screen reader and keyboard users come across is lengthy nav bars
 3. Identify links with generic text ('Click here', 'Read more').
   * Check for the ```title``` or ```ARIA``` attributes to provide context or additional off-screen text.
 
-### Links that open in a New Window
+### Links that open in a new window
 1. Identify links that open in new windows.
 2. Check that ```target='_blank'```.
 3. Verify that some indication is given programmatically.
@@ -30,7 +30,7 @@ The other issue screen reader and keyboard users come across is lengthy nav bars
   *  ```<a href='#' target='_blank' title='Opens in new window'>```
   *  ```<a href='#' target='_blank'>Link<span class='sr-only'>Opens in new window</span></a>```
 
-### Skip Navigation
+### Skip navigation
 
 1. First compare the pages on the site for links that are repeated at the beginning of the tab order.
   * `Skip Navigation` is not needed if repetitive nav links are not used.
@@ -60,7 +60,7 @@ Keyboard Access <a href='../keyboard/' aria-label="Keyboard Access">Click Here</
 
 > These links are not unique, but the ```title``` attribute in the first link gives a screen reader user context and the ```aria-label``` provides the context in the second link.
 
-#### Skip Navigation
+#### Skip navigation
 
 ```html
 //This is the code used on this guide

--- a/pages/tables.md
+++ b/pages/tables.md
@@ -29,7 +29,7 @@ If a table has text associated with it, ensure the text is programatically linke
 
 ### Passes
 
-#### Simple Table
+#### Simple table
 
 <table>
   <caption>User's Height and Weight</caption>

--- a/pages/tools.md
+++ b/pages/tools.md
@@ -16,7 +16,6 @@ sidenav: docs
 
 ### Color impairment
 * [Color Oracle](http://colororacle.org/) is another desktop application for simulating color impairment on your entire screen.
-* [Daltonize](http://daltonize.appspot.com/) is a collection of bookmarklets that simulate the three most common forms of color impairment (protanopia, deuteranopia, and tritanopia) on any web page.
 * [colourblind](https://github.com/Altreus/colourblind) is another simulation tool similar to Daltonize, but with more options (protanopia, protanomaly, deuteranopia, deuteranomaly, tritanopia, tritanomaly, achromatopsia, and achromatomaly) in a single bookmarklet.
 * [postcss-colorblind](https://github.com/btholt/postcss-colorblind) is a CSS build tool that modifies colors in your CSS to simulate [four common impairment groups](https://github.com/skratchdot/color-blind#color-blindness-table).
 
@@ -31,7 +30,7 @@ These tools can be used to test sites for Section 508 and WCAG compliance in bro
 * The [W3C](http://www.w3.org/) maintains a comprehensive [list of web accessibility evaluation tools](http://www.w3.org/WAI/ER/tools/).
 
 ## Autocomplete widgets
-These JavaScript widgets produce HTML with [ARIA autocomplete] attributes:
+These JavaScript widgets produce HTML with ARIA autocomplete attributes:
 
 * [Awesomplete](http://leaverou.github.io/awesomplete/) is dependency-free
 * [jQuery UI autocomplete](http://jqueryui.com/autocomplete/) requires jQuery
@@ -52,5 +51,3 @@ development process:
 * [webalin](http://webalin.readthedocs.org/en/latest/) is a Python-based 508 compliance linter for HTML.
 
 There are many other [npm](https://www.npmjs.com/) packages tagged [wcag](https://www.npmjs.com/search?q=wcag) and [a11y](https://www.npmjs.com/search?q=a11y).
-
-[ARIA autocomplete]: http://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete

--- a/pages/tools.md
+++ b/pages/tools.md
@@ -7,20 +7,20 @@ layout: post
 sidenav: docs
 ---
 
-## Color Tools
+## Color tools
 * [WebAIM color contrast checker](http://webaim.org/resources/contrastchecker/) compares two hex colors and tells you whether they meet WCAG AA and AAA contrast thresholds.
 * [Snook's color contrast analyzer](http://snook.ca/technical/colour_contrast/colour.html) lets you adjust RGB and HSV values and reports contrast compliance interactively.
 * [NC State palette accessibility evaluator](http://accessibility.oit.ncsu.edu/tools/color-contrast/) lets you compare contrast between three or more colors for WCAG AA or AAA compliance.
 * [Color Safe](http://colorsafe.co/) is a guide for choosing colors that meet WCAG contrast thresholds.
 * [Color Contrast Analyzer](http://www.paciellogroup.com/resources/contrastanalyser/) is a desktop application for contrast checking that also simulates different forms of color impairment.
 
-### Color Impairment
+### Color impairment
 * [Color Oracle](http://colororacle.org/) is another desktop application for simulating color impairment on your entire screen.
 * [Daltonize](http://daltonize.appspot.com/) is a collection of bookmarklets that simulate the three most common forms of color impairment (protanopia, deuteranopia, and tritanopia) on any web page.
 * [colourblind](https://github.com/Altreus/colourblind) is another simulation tool similar to Daltonize, but with more options (protanopia, protanomaly, deuteranopia, deuteranomaly, tritanopia, tritanomaly, achromatopsia, and achromatomaly) in a single bookmarklet.
 * [postcss-colorblind](https://github.com/btholt/postcss-colorblind) is a CSS build tool that modifies colors in your CSS to simulate [four common impairment groups](https://github.com/skratchdot/color-blind#color-blindness-table).
 
-## Accessibility Review Tools
+## Accessibility review tools
 These tools can be used to test sites for Section 508 and WCAG compliance in browser:
 
 * [Accessibility Insights](https://accessibilityinsights.io/) - Browser plugin (Chrome, Edge), Android and Windows applications for automated and guided manual testing for accessibility including WCAG 2.0 and 2.1. 
@@ -30,14 +30,14 @@ These tools can be used to test sites for Section 508 and WCAG compliance in bro
 * [WAVE](http://wave.webaim.org/) is an accessibility auditor and browser extension with document inspection features.
 * The [W3C](http://www.w3.org/) maintains a comprehensive [list of web accessibility evaluation tools](http://www.w3.org/WAI/ER/tools/).
 
-## Autocomplete Widgets
+## Autocomplete widgets
 These JavaScript widgets produce HTML with [ARIA autocomplete] attributes:
 
 * [Awesomplete](http://leaverou.github.io/awesomplete/) is dependency-free
 * [jQuery UI autocomplete](http://jqueryui.com/autocomplete/) requires jQuery
 * [Select2](https://select2.github.io/) also requires jQuery
 
-## Automated Testing
+## Automated testing
 
 Automated testing tools can help you find some of the more common accessibility mistakes quickly, however no automated tool can detect all accessibility issues. [A recent experiment by the UK's Government Digital Service](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/) found that the best automated tools only caught about 40 percent of the errors on a test site; some of the most popular tools caught less than 20 percent. Whatever automated tool you use, be sure to also do manual testing. 
 These tools can be used in automated tests and with continuous integration

--- a/pages/videos.md
+++ b/pages/videos.md
@@ -7,8 +7,6 @@ layout: post
 sidenav: docs
 ---
 
-## Training and videos
-
 There are tons of great talks and videos about accessibility online. This is a collection of videos we found useful.
 
 ### #ID24 2016: The Web Accessibility Basics w/ Marco Zehe

--- a/pages/writingguide.md
+++ b/pages/writingguide.md
@@ -7,7 +7,7 @@ layout: post
 sidenav: docs
 ---
 
-## The Law
+## The law
 
 Section 508 is part of the 'Rehabilitation Act of 1973.' The law was amended in 1998 to add 508 which requires that government agencies provide equal access to information to disabled employees.
 
@@ -19,13 +19,13 @@ The correct way to refer to the law is:
 
 While related in ways, the Rehabilitation Act is not part of the Americans with Disabilities Act.
 
-## Key Words
+## Key words
 
 * __Conformance:__ We conform with the standards of Section 508, not the law of section 508.
 
 * __Compliance:__ A government agency is in compliance with the law.
 
-## Talking Points
+## Talking points
 
 * The goal of accessibility at 18F is to build sites that are usable by everyone, not to meet minimum standards
 * We focus on building accessibility into every step of a project, from design to each sprint review


### PR DESCRIPTION
## This PR
- I noticed inconsistencies with heading and subheading casing. I converted all to sentence casing in line with the 18F Content Guide.
- Minor edits, such as changing `i.e.` to `e.g.` when it denotes "for example"

## Other observations
### Broken links
I noticed a couple broken links on the [`tools` page](https://accessibility.18f.gov/tools/)
- Daltonize
- ARIA autocomplete
### Capitalization inconsistencies
- For example, `ARIA` vs. `Aria`
### Nav bug
- I noticed when the user is on the `writing-guide` page, the corresponding nav item isn’t selected, while the other pages are selected when active.