### PR TITLE
bump to newer ruby in pa11y.yml

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install jekyll site dependencies.
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7.2
           bundler-cache: true
 
       - name: Install pa11y-ci dependencies.


### PR DESCRIPTION
to match what we're running on federalist - should fix the workflow build errors