### PR TITLE
 Digital council identifier updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,27 @@ $ brew update
 $ brew install ruby
 ```
 
+You will also need the the [Bundler gem](http://bundler.io/) for this project:
+
+```shell
+$ gem install bundler 
+```
+
 To serve 18F Accessibility Guide locally, using `accessibility` as the name of your new repository:
 
 ```shell
 $ git clone https://github.com/18F/accessibility.git accessibility
 $ cd accessibility
-$ ./go serve
+$ bundle install
+$ bundle exec jekyll serve
 ```
 
-This will check that your Ruby version is supported, install the [Bundler
-gem](http://bundler.io/) if it is not yet installed, install all the gems
-needed by the template, and launch a running instance on
-`http://localhost:4000/`. (Make sure to include the trailing slash! The built-in
-Jekyll webserver doesn’t redirect to it.) You can see how your local copy of accessibility renders
+This will install all the gems needed by the template, and launch a running instance on
+`http://localhost:4000`. You can see how your local copy of accessibility renders
 at any time by going to that URL. To stop serving locally, simply type `Ctrl+C`
 into the terminal again.
 
-After going through these steps, run `./go` to see a list of available
-commands. The `serve` command is the most common for routine development.
+Note: The main branch of this project is 18f-pages. Please submit all PRs against that branch.
 
 ### Forking into your own repository
 

--- a/_config.yml
+++ b/_config.yml
@@ -53,14 +53,13 @@ exclude:
 - vendor
 - node_modules
 
-markdown: kramdown
 highlighter: rouge
 permalink: pretty
 
 incremental: true
 
 sass:
-  style: :compressed
+  style: compressed
 
 # Author/Organization info to be displayed in the templates
 author:

--- a/_data/usa_identifier.yaml
+++ b/_data/usa_identifier.yaml
@@ -29,3 +29,4 @@ identifier_data:
     budget_performance_url: "https://www.gsa.gov/reference/reports/budget-performance"
     accessibility_url: "https://www.gsa.gov/website-information/accessibility-aids"
     usagov_contact_url: "https://www.usa.gov/contact"
+    privacy_policy_url: "https://www.gsa.gov/website-information/website-policies"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 {% assign identifier = site.data.usa_identifier.identifier_data[0] %}
 
-<div class="usa-identifier">
+<footer class="usa-identifier">
   <section>
     <div class="usa-footer__secondary-section">
       <div class="grid-container">
@@ -75,4 +75,4 @@
       <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
     </div>
   </section>
-</div>
+</footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,21 @@
 {% assign identifier = site.data.usa_identifier.identifier_data[0] %}
+
 <div class="usa-identifier">
+  <section>
+    <div class="usa-footer__secondary-section">
+      <div class="grid-container">
+        <div class="grid-row grid-gap">
+          <div class="usa-footer__contact-links mobile-lg:grid-col-12">
+            <div class="usa-footer grid-row grid-gap-1">
+              <div class="grid-col-auto text-base-darkest">
+                Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ identifier.site_email }}">{{ identifier.site_email }}</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
   <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
     <div class="usa-identifier__container">
       <div class="usa-identifier__logos">
@@ -43,6 +59,11 @@
         <li class="usa-identifier__required-links-item">
           <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
             View No FEAR Act data
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="View privacy policy">
+            Privacy policy
           </a>
         </li>
       </ul>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,8 +6,13 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="usa-footer__contact-links mobile-lg:grid-col-12">
-            <div class="usa-footer grid-row grid-gap-1">
-              <div class="grid-col-auto text-base-darkest">
+            <div class="usa-footer grid-row">
+              <div class="grid-col-auto">
+                This project is maintained by <a class="usa-link" href="https://18f.gsa.gov/">18F</a>
+                </div>
+            </div>
+            <div class="usa-footer grid-row">
+              <div class="grid-col-auto">
                 Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ identifier.site_email }}">{{ identifier.site_email }}</a>
               </div>
             </div>
@@ -38,35 +43,40 @@
       <div class="usa-identifier__container">
         <ul class="usa-identifier__required-links-list">
           <li class="usa-identifier__required-links-item">
-            <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">
-              Report fraud, waste, or abuse to the Office of the Inspector General
-            </a>
-          </li>
-          <li class="usa-identifier__required-links-item">
-            <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
-              Submit a Freedom of Information Act (FOIA) request
-            </a>
-          </li>
-          <li class="usa-identifier__required-links-item">
-            <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
-              View budget and performance reports
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.agency_about_url }}" title="About GSA">
+              About GSA
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
             <a class="usa-identifier__required-link usa-link" href="{{ identifier.accessibility_url }}" title="View accessibility statement">
-              View accessibility statement
+              Accessibility support
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
+              FOIA requests
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
             <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
-              View No FEAR Act data
+              No FEAR Act data
+            </a>
+          </li> 
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Office of the Inspector General">
+              Office of the Inspector General
+            </a>
+          </li>                   
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
+              Performance reports
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="View privacy policy">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy-url }}" title="Our privacy policy">
               Privacy policy
             </a>
-          </li>
+          </li>       
         </ul>
       </div>
     </nav>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,8 +8,8 @@
           <div class="usa-footer__contact-links mobile-lg:grid-col-12">
             <div class="usa-footer grid-row">
               <div class="grid-col-auto">
-                This project is maintained by <a class="usa-link" href="https://18f.gsa.gov/">18F</a>
-                </div>
+                This project is maintained by <a class="usa-link" href="{{ identifier.org_secondary_url }}">18F</a>
+              </div>
             </div>
             <div class="usa-footer grid-row">
               <div class="grid-col-auto">
@@ -30,7 +30,7 @@
           </a>
         </div>
         <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
-          <p class="usa-identifier__identity-domain">18F Accessibility Guide</p>
+          <p class="usa-identifier__identity-domain">{{ identifier.site_name }}</p>
           <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
             <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">
               GSA’s Technology Transformation Services

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 {% assign identifier = site.data.usa_identifier.identifier_data[0] %}
 
-<footer class="usa-identifier">
+<footer class="usa-footer">
   <section>
     <div class="usa-footer__secondary-section">
       <div class="grid-container">
@@ -16,63 +16,65 @@
       </div>
     </div>
   </section>
-  <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
-    <div class="usa-identifier__container">
-      <div class="usa-identifier__logos">
-        <a href="https://www.gsa.gov/" class="usa-identifier__logo">
-          <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/images/{{ identifier.agency_logo }}" alt="GSA logo" role="img" />
-        </a>
+  <div class="usa-identifier">
+    <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
+      <div class="usa-identifier__container">
+        <div class="usa-identifier__logos">
+          <a href="https://www.gsa.gov/" class="usa-identifier__logo">
+            <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/images/{{ identifier.agency_logo }}" alt="GSA logo" role="img" />
+          </a>
+        </div>
+        <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
+          <p class="usa-identifier__identity-domain">18F Accessibility Guide</p>
+          <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
+            <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">
+              GSA’s Technology Transformation Services
+            </a>
+          </p>
+        </div>
       </div>
-      <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
-        <p class="usa-identifier__identity-domain">18F Accessibility Guide</p>
-        <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
-          <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">
-            GSA’s Technology Transformation Services
-          </a>
-        </p>
+    </section>
+    <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
+      <div class="usa-identifier__container">
+        <ul class="usa-identifier__required-links-list">
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">
+              Report fraud, waste, or abuse to the Office of the Inspector General
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
+              Submit a Freedom of Information Act (FOIA) request
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
+              View budget and performance reports
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.accessibility_url }}" title="View accessibility statement">
+              View accessibility statement
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
+              View No FEAR Act data
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="View privacy policy">
+              Privacy policy
+            </a>
+          </li>
+        </ul>
       </div>
-    </div>
-  </section>
-  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
-    <div class="usa-identifier__container">
-      <ul class="usa-identifier__required-links-list">
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Report fraud, waste, or abuse to the Office of the Inspector General">
-            Report fraud, waste, or abuse to the Office of the Inspector General
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
-            Submit a Freedom of Information Act (FOIA) request
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
-            View budget and performance reports
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.accessibility_url }}" title="View accessibility statement">
-            View accessibility statement
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
-            View No FEAR Act data
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="View privacy policy">
-            Privacy policy
-          </a>
-        </li>
-      </ul>
-    </div>
-  </nav>
-  <section class="usa-identifier__section usa-identifier__section--usagov" aria-label="U.S. government information and services">
-    <div class="usa-identifier__container">
-      <div class="usa-identifier__usagov-description text-base-lightest">Looking for U.S. government information and services?</div>
-      <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
-    </div>
-  </section>
-</footer>
+    </nav>
+    <section class="usa-identifier__section usa-identifier__section--usagov" aria-label="U.S. government information and services">
+      <div class="usa-identifier__container">
+        <div class="usa-identifier__usagov-description text-base-lightest">Looking for U.S. government information and services?</div>
+        <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+      </div>
+    </section>
+  </div>
+  </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
           <div class="usa-footer__contact-links mobile-lg:grid-col-12">
             <div class="usa-footer grid-row">
               <div class="grid-col-auto">
-                This project is maintained by <a class="usa-link" href="{{ identifier.org_secondary_url }}">18F</a>
+                This project is maintained by <a class="usa-link" href="{{ identifier.org_secondary_url }}">{{ identifier.org_secondary }}</a>
               </div>
             </div>
             <div class="usa-footer grid-row">
@@ -73,7 +73,7 @@
             </a>
           </li>
           <li class="usa-identifier__required-links-item">
-            <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy-url }}" title="Our privacy policy">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="Our privacy policy">
               Privacy policy
             </a>
           </li>       
@@ -87,4 +87,4 @@
       </div>
     </section>
   </div>
-  </footer>
+</footer>


### PR DESCRIPTION
This PR:
* Updates the README (I struggled getting the project running until I realized that I was trying to use out-of-date instructions on the wrong branch)
* Adds 18F@gsa.gov as a contact as part of the identifier (and changes the text font, the default for the identifier on this project is not accessible with the gray background) 
* Adds a link to the privacy policy.

Thanks to @igorkorenfeld for doing the initial work [here](https://github.com/18F/brand/pull/280)