### PR TITLE
Add CSS definition

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
     name: Building site and running pa11y-ci tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout source.

--- a/pages/css.md
+++ b/pages/css.md
@@ -6,7 +6,7 @@ page_title: CSS dependence
 layout: post
 sidenav: docs
 ---
-CSS dependence refers to sites that rely on CSS to be functional or understandable. This is a concern for accessibility because most assistive technology ignores CSS. 
+Cascading style sheets ([CSS](https://www.section508.gov/content/glossary/#sectionC)) allow us to add and manage styles (e.g., fonts, colors, size, spacing) on web pages. CSS dependence refers to sites that rely on CSS to be functional or understandable. This is a concern for accessibility because most assistive technology ignores CSS. 
 
 For example, images displayed through CSS are completely ignored by assistive technology. Images loaded by CSS do not have alt attributes and would require the images content to be displayed in some other manner on the page. It is recommended that all CSS images be decorative and content images be on the page with `<img>` tags.
 


### PR DESCRIPTION
Added definition of CSS as per https://github.com/18F/TLC-crew/issues/177; linked to Section 508 site for more info.

I did not add an external link icon because they don't appear on other external links in this guide. We should have a consistent policy for external links on the guides once they are moved into one repo. 